### PR TITLE
Portability fixes

### DIFF
--- a/src/dual/CMakeLists.txt
+++ b/src/dual/CMakeLists.txt
@@ -124,4 +124,6 @@ target_include_directories(dual PRIVATE src)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(dual PRIVATE $<$<COMPILE_LANGUAGE:CXX>:-fbracket-depth=8192>)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  target_compile_options(dual PRIVATE /bigobj)
 endif()

--- a/src/dual/include/dual/nds/arm7/spi.hpp
+++ b/src/dual/include/dual/nds/arm7/spi.hpp
@@ -63,7 +63,7 @@ namespace dual::nds::arm7 {
 
       std::unique_ptr<Device> m_firmware{};
       std::unique_ptr<Device> m_touch_screen{};
-      Device* m_device_table[4];
+      Device* m_device_table[4]{};
   };
 
 } // namespace dual::nds::arm7


### PR DESCRIPTION
- Fixes the SPI device table not properly being initialized, which would cause my Windows Clang executable to crash on opening the emulator
- Fixes the tablegen code not compiling under MSVC. I did not fix the rest of MSVC compilation though, as it's relatively non-trivial to do so properly